### PR TITLE
Add support to manage Sentry project name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 pkg/
 .DS_Store
+tmp/

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -111,6 +111,9 @@ func New(c *logical.BackendConfig) *backend {
 					logical.UpdateOperation: &framework.PathOperation{
 						Callback: handleProjectUpdate,
 					},
+					logical.DeleteOperation: &framework.PathOperation{
+						Callback: handleProjectDelete,
+					},
 				},
 			},
 			{

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -86,7 +86,7 @@ func New(c *logical.BackendConfig) *backend {
 					"project": {
 						Type:        framework.TypeString,
 						Required:    true,
-						Description: "Name of the project in sentry",
+						Description: "Name of the project in Vault",
 					},
 					"team": {
 						Type:        framework.TypeString,
@@ -97,6 +97,11 @@ func New(c *logical.BackendConfig) *backend {
 						Type:        framework.TypeString,
 						Required:    false,
 						Description: "DSN label to use by default when not specified",
+					},
+					"sentry_project": {
+						Type:        framework.TypeString,
+						Required:    false,
+						Description: "Name of the project in sentry",
 					},
 				},
 				Operations: map[logical.Operation]framework.OperationHandler{

--- a/backend/path-dsn.go
+++ b/backend/path-dsn.go
@@ -50,7 +50,7 @@ func handleDsnRead(ctx context.Context, req *logical.Request, data *framework.Fi
 	}
 
 	if vaultProject == nil {
-		return logical.ErrorResponse("vaultProject %s is not configured", vaultProjectName), nil
+		return logical.ErrorResponse("project %s is not configured", vaultProjectName), nil
 	}
 
 	if dsnName == "" {
@@ -58,7 +58,7 @@ func handleDsnRead(ctx context.Context, req *logical.Request, data *framework.Fi
 	}
 
 	if dsnName == "" {
-		return logical.ErrorResponse("default DSN label is not set for vaultProject %s", vaultProjectName), nil
+		return logical.ErrorResponse("default DSN label is not set for project %s", vaultProjectName), nil
 	}
 
 	dsn, err := loadDsn(ctx, req.Storage, vaultProjectName, dsnName)

--- a/backend/path-dsn.go
+++ b/backend/path-dsn.go
@@ -41,27 +41,27 @@ func loadDsn(ctx context.Context, storage logical.Storage, project, label string
 }
 
 func handleDsnRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	projectName := data.Get("project").(string)
+	vaultProjectName := data.Get("project").(string)
 	dsnName := data.Get("name").(string)
 
-	project, err := loadProject(ctx, req.Storage, projectName)
+	vaultProject, err := loadProject(ctx, req.Storage, vaultProjectName)
 	if err != nil {
 		return nil, err
 	}
 
-	if project == nil {
-		return logical.ErrorResponse("project %s is not configured", projectName), nil
+	if vaultProject == nil {
+		return logical.ErrorResponse("vaultProject %s is not configured", vaultProjectName), nil
 	}
 
 	if dsnName == "" {
-		dsnName = project.DefaultDsnLabel
+		dsnName = vaultProject.DefaultDsnLabel
 	}
 
 	if dsnName == "" {
-		return logical.ErrorResponse("default DSN label is not set for project %s", projectName), nil
+		return logical.ErrorResponse("default DSN label is not set for vaultProject %s", vaultProjectName), nil
 	}
 
-	dsn, err := loadDsn(ctx, req.Storage, projectName, dsnName)
+	dsn, err := loadDsn(ctx, req.Storage, vaultProjectName, dsnName)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func handleDsnRead(ctx context.Context, req *logical.Request, data *framework.Fi
 	key, err := fetchKeyOrMakeNew(
 		client,
 		sentry.Organization{Slug: &config.Name},
-		sentry.Project{Slug: &project.Name},
+		sentry.Project{Slug: &vaultProject.DisplayName},
 		dsnName,
 	)
 
@@ -102,7 +102,7 @@ func handleDsnRead(ctx context.Context, req *logical.Request, data *framework.Fi
 		DSN:  key.DSN.Public,
 	}
 
-	entry, err := logical.StorageEntryJSON(KeyDsnPrefix+projectName+"/"+dsnName, item)
+	entry, err := logical.StorageEntryJSON(KeyDsnPrefix+vaultProjectName+"/"+dsnName, item)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/path-dsn_test.go
+++ b/backend/path-dsn_test.go
@@ -49,7 +49,7 @@ func testReadDsnErr(project, dsnname, msg string) logicaltest.TestStep {
 }
 
 func testReadDefaultDsn(org, project, dsnname string) logicaltest.TestStep {
-	localSentry.handleStatic(fmt.Sprintf("/projects/%s/%s/keys/", org, project), http.StatusOK, fmt.Sprintf(getClientKeyResponseBody, dsnname))
+	localSentry.handleStatic(fmt.Sprintf("/projects/%s/display-name-%s/keys/", org, project), http.StatusOK, fmt.Sprintf(getClientKeyResponseBody, dsnname))
 
 	return logicaltest.TestStep{
 		Operation: logical.ReadOperation,
@@ -71,7 +71,7 @@ func testReadDefaultDsn(org, project, dsnname string) logicaltest.TestStep {
 }
 
 func testReadDsn(org, project, dsnname string) logicaltest.TestStep {
-	localSentry.handleStatic(fmt.Sprintf("/projects/%s/%s/keys/", org, project), http.StatusOK, fmt.Sprintf(getClientKeyResponseBody, dsnname))
+	localSentry.handleStatic(fmt.Sprintf("/projects/%s/display-name-%s/keys/", org, project), http.StatusOK, fmt.Sprintf(getClientKeyResponseBody, dsnname))
 
 	return logicaltest.TestStep{
 		Operation: logical.ReadOperation,

--- a/backend/path-project.go
+++ b/backend/path-project.go
@@ -73,9 +73,24 @@ func handleProjectsList(ctx context.Context, req *logical.Request, data *framewo
 }
 
 func handleProjectUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	projectName := data.Get("project").(string)
+	vaultProjectName := data.Get("project").(string)
+	sentryProjectName := data.Get("sentry_project").(string)
 	teamName := data.Get("team").(string)
 	defaultDsnLabel := data.Get("default_dsn_label").(string)
+
+	if sentryProjectName == "" {
+		sentryProjectName = vaultProjectName
+
+		// Lookup Vault storage for sentry project name, might be name set in earlier request(s)
+		vaultProject, err := loadProject(ctx, req.Storage, vaultProjectName)
+		if err != nil {
+			return nil, err
+		}
+
+		if vaultProject != nil {
+			sentryProjectName = vaultProject.DisplayName
+		}
+	}
 
 	config, err := loadConfig(ctx, req.Storage)
 	if err != nil {
@@ -93,9 +108,9 @@ func handleProjectUpdate(ctx context.Context, req *logical.Request, data *framew
 
 	// Attempt to read project from sentry or create a new one
 	// if the project does not exist.
-	p, err := client.GetProject(sentry.Organization{
+	sentryProject, err := client.GetProject(sentry.Organization{
 		Slug: &config.Name,
-	}, projectName)
+	}, sentryProjectName)
 
 	if err != nil {
 		apiErr, ok := err.(sentry.APIError)
@@ -107,10 +122,10 @@ func handleProjectUpdate(ctx context.Context, req *logical.Request, data *framew
 			return logical.ErrorResponse("failed to read project information from sentry. %s", apiErr), nil
 		}
 
-		p, err = client.CreateProject(
+		sentryProject, err = client.CreateProject(
 			sentry.Organization{Slug: &config.Name},
 			sentry.Team{Slug: &teamName},
-			projectName,
+			sentryProjectName,
 			nil,
 		)
 
@@ -120,14 +135,14 @@ func handleProjectUpdate(ctx context.Context, req *logical.Request, data *framew
 	}
 
 	item := &SentryProject{
-		Name:            projectName,
-		DisplayName:     p.Name,
+		Name:            vaultProjectName,
+		DisplayName:     sentryProject.Name,
 		Org:             config.Name,
 		Team:            teamName,
 		DefaultDsnLabel: defaultDsnLabel,
 	}
 
-	entry, err := logical.StorageEntryJSON(KeyProjectConfigPrefix+projectName, item)
+	entry, err := logical.StorageEntryJSON(KeyProjectConfigPrefix+vaultProjectName, item)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/path-project_test.go
+++ b/backend/path-project_test.go
@@ -25,6 +25,7 @@ func TestHandleProject(t *testing.T) {
 			testListProjects("existing-project", "fresh-project", "frs"),
 			testWriteProjectExisting("project-org", "project-with-default-dsn", "test-team", "default-dsn-for-tests"),
 			testReadProject("project-with-default-dsn", "display-name-project-with-default-dsn", "project-org", "test-team", "default-dsn-for-tests"),
+			testDeleteProject("project-with-default-dsn"),
 		},
 	})
 }
@@ -187,6 +188,25 @@ func testReadProjectErr(name, msg string) logicaltest.TestStep {
 
 			if !strings.Contains(resp.Error().Error(), msg) {
 				return fmt.Errorf("unexpected error message %q does not match %q", resp.Error(), msg)
+			}
+
+			return nil
+		},
+	}
+}
+
+func testDeleteProject(name string) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.DeleteOperation,
+		Path:      "project/" + name,
+		Check: func(resp *logical.Response) error {
+			expect := map[string]interface{}{
+				logical.HTTPContentType: "application/json",
+				logical.HTTPStatusCode:  http.StatusOK,
+			}
+
+			if !cmp.Equal(expect, resp.Data) {
+				return fmt.Errorf("unexpected data in read response. %s", cmp.Diff(expect, resp.Data))
 			}
 
 			return nil


### PR DESCRIPTION
**Add support to manage Sentry project name**
Old:
```
vault write sentry/project/frs team=shuttl default_dsn_label=STAGING
```
New:
```
vault write sentry/project/frs team=shuttl default_dsn_label=STAGING sentry_project=free-ride-service
```
```
vault write sentry/project/frs team=shuttl default_dsn_label=STAGING 

In this case, sentry project name will be **frs**
````

**New endpoint to delete project from Vault**
```
vault delete sentry/project/frs
```
![image](https://user-images.githubusercontent.com/2921303/95979684-a7701f80-0e39-11eb-8b3e-758e12cf0814.png)
